### PR TITLE
Added composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "jonbish/remove-slug-from-custom-post-type",
+    "description": "Remove Slug From Custom Post Type",
+    "minimum-stability" : "stable",
+    "type": "wordpress-plugin",
+    "authors": [
+        {
+            "name": "Jon Bishop",
+            "email": "jonbish@gmail.com"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
Added composer file so that plugin can be installed that way. The parent project's `composer.json` would need to have the following settings:

```json
{
  "repositories": [
    {
       "type": "vcs",
       "url": "https://github.com/jonbish/remove-slug-from-custom-post-type"
    }
  ],
  "requirements": {
    "jonbish/remove-slug-from-custom-post-type": "dev-master"
  }

}
```